### PR TITLE
Relax `phoenix_live_view` dependency constraint to allow for v`0.20`-series use without `override: true`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule ChoreRunner.MixProject do
     [
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:floki, ">= 0.30.0", only: :test},
-      {:phoenix_live_view, "~> 0.19.3"},
+      {:phoenix_live_view, "~> 0.19"},
       {:phoenix_view, "~> 2.0"},
       {:telemetry, "~> 1.1"}
     ]


### PR DESCRIPTION
This should allow us to gracefully upgrade to LV 0.20.

Without the sub-version specified, `~0.19` should mean `>=0.19.0 and <1.0.0` per:
https://hexdocs.pm/elixir/Version.html#module-requirements